### PR TITLE
Add support for language files with ISO-3166 country names

### DIFF
--- a/library-project/src/core/CMakeLists.txt
+++ b/library-project/src/core/CMakeLists.txt
@@ -15,6 +15,7 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_PROJECT_NAME}Config.cmake.in
     "
 )
 
+string(LENGTH "${CMAKE_PROJECT_NAME}_" I18N_BASENAME_LENGTH)
 configure_file(Info.h.in ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_PROJECT_NAME}Info.h @ONLY)
 
 create_library(

--- a/library-project/src/core/Info.h.in
+++ b/library-project/src/core/Info.h.in
@@ -84,7 +84,7 @@ public:
         for (const QString &translation : std::as_const(langList)) {
             QTranslator *translator = new QTranslator;
             std::ignore = translator->load(translation, dir.absolutePath());
-            QString lang = translation.mid(6, 2);
+            QString lang = translation.mid(@I18N_BASENAME_LENGTH@, translation.lastIndexOf('.'). - @I18N_BASENAME_LENGTH@);
             @CMAKE_PROJECT_NAME@_translations.insert(lang, translator);
         }
         return @CMAKE_PROJECT_NAME@_translations;

--- a/library-project/translations/CMakeLists.txt
+++ b/library-project/translations/CMakeLists.txt
@@ -4,6 +4,28 @@ set_directory_properties(PROPERTIES CLEAN_NO_CUSTOM 1)
 option(CLEAN_TRS "Clean Obsolete translations from tr files" FALSE)
 find_package(Qt6 ${REQUIRED_QT_VERSION} REQUIRED COMPONENTS LinguistTools)
 
+# Set the projects Translation files below
+# Exsiting files will be updated when the project is built
+# Non Exsiting files will be geneated new empty files for the language.
+#
+# All Languge files must be named in one of the following formats
+# Always use the first form unless the target language is a Country specific variant (ie. zh_CN, zh_TW, pt_BR)
+#
+# ProjectName_lc.ts
+#           OR
+# ProjectName_lc_CC.ts
+#
+# ProjectName is the project name the same as the CMAKE_PROJECT_NAME variable
+#
+# lc is the Language Code. A ISO-639 alpha-2 code,
+#   lc Must be lowercase.
+#   Must be in the `SET 1` column of https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes
+
+#
+# CC is the Country Code. A valid ISO 3166-1 alpha-2 code
+#    CC Must be uppercase
+#    Must be in the `CODE` column of https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements
+#
 set(PACKAGE_TRS
     #THE TS FILES IN THIS DIRECTORY TO INCLUDE
 )

--- a/library-project/translations/CMakeLists.txt
+++ b/library-project/translations/CMakeLists.txt
@@ -2,7 +2,7 @@
 set_directory_properties(PROPERTIES CLEAN_NO_CUSTOM 1)
 
 option(CLEAN_TRS "Clean Obsolete translations from tr files" FALSE)
-find_package(Qt6LinguistTools)
+find_package(Qt6 ${REQUIRED_QT_VERSION} REQUIRED COMPONENTS LinguistTools)
 
 set(PACKAGE_TRS
     #THE TS FILES IN THIS DIRECTORY TO INCLUDE

--- a/library-project/translations/README.md
+++ b/library-project/translations/README.md
@@ -1,7 +1,15 @@
 # About this Directory
-This is the `translations` directory its contains
+This is the `translations` directory it contains
 
   - `CMakeLists.txt` - Instructions to build the translations
-  - additional PROJECT_NAME_<lang>.ts file per language
+  - additional ts files for supported translations
 
- Translations will be automaticly generated if ts files are added to the PROJECT_TRS var in `CMakeLists.txt`
+ Translations will be automaticly generated if ts files are added to the PROJECT_TRS var in `CMakeLists.txt`.
+
+ When adding new language files they must be in the form
+  - `PROJECT_LANG.ts`
+  - `PROJECT_LANG_COUNTRY.ts`
+
+  `PROJECT` is the name of the project <br/>
+  `LANG` is a valid ISO-639 alpha-2 code (From the `SET 1` Column in this [Table](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes) ) <br/>
+  `COUNTRY` is a valid ISO 3166-1 alpha-2 code (From the `CODE` column this [Table](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements)) <br/>


### PR DESCRIPTION
 - Find linguistTools the recommend way
 - Support loading tr files with Iso-3166-1 county (i.e foo_en_US.ts)